### PR TITLE
Fixed issues with trackpads

### DIFF
--- a/Editor/InspectorGraph/InspectorGraph.cs
+++ b/Editor/InspectorGraph/InspectorGraph.cs
@@ -113,7 +113,12 @@ namespace GiantParticle.InspectorGraph.Editor
             footer.Add(zoomController);
             zoomController.ZoomLevelChanged += element => UpdateWindowVisibility();
 
-            var moveManipulator = new DragManipulator(_windowView, _content, ManipulatorButton.Middle);
+            var moveManipulator = new DragManipulator(_windowView, _content,
+                new[]
+                {
+                    new ActivatorCombination(ManipulatorButton.Middle),
+                    new ActivatorCombination(ManipulatorButton.Left, EventModifiers.Command | EventModifiers.Alt)
+                });
             moveManipulator.PositionChanged += element => UpdateWindowVisibility();
 
             _toolbar.LoadPreferences();

--- a/Editor/InspectorGraph/InspectorGraph.cs
+++ b/Editor/InspectorGraph/InspectorGraph.cs
@@ -117,7 +117,11 @@ namespace GiantParticle.InspectorGraph.Editor
                 new[]
                 {
                     new ActivatorCombination(ManipulatorButton.Middle),
-                    new ActivatorCombination(ManipulatorButton.Left, EventModifiers.Command | EventModifiers.Alt)
+                    Application.platform == RuntimePlatform.OSXEditor
+                        ? new ActivatorCombination(ManipulatorButton.Left,
+                            EventModifiers.Alt | EventModifiers.Command)
+                        : new ActivatorCombination(ManipulatorButton.Left,
+                            EventModifiers.Alt | EventModifiers.Control)
                 });
             moveManipulator.PositionChanged += element => UpdateWindowVisibility();
 

--- a/Editor/InspectorGraph/Manipulators/BaseDragManipulator.cs
+++ b/Editor/InspectorGraph/Manipulators/BaseDragManipulator.cs
@@ -97,8 +97,7 @@ namespace GiantParticle.InspectorGraph.Editor.Manipulators
             bool activate = false;
             for (int i = 0; i < _activators.Length; ++i)
             {
-                ActivatorCombination combination = _activators[i];
-                if (combination.ShouldActivate(evt))
+                if (_activators[i].ShouldActivate(evt))
                 {
                     activate = true;
                     break;

--- a/Editor/InspectorGraph/Manipulators/BaseDragManipulator.cs
+++ b/Editor/InspectorGraph/Manipulators/BaseDragManipulator.cs
@@ -19,12 +19,37 @@ namespace GiantParticle.InspectorGraph.Editor.Manipulators
         Middle = 2
     }
 
+    internal struct ActivatorCombination
+    {
+        public ManipulatorButton MouseButton;
+        public EventModifiers Modifiers;
+
+        public ActivatorCombination(ManipulatorButton mouseButton)
+        {
+            MouseButton = mouseButton;
+            Modifiers = EventModifiers.None;
+        }
+
+        public ActivatorCombination(ManipulatorButton mouseButton, EventModifiers modifiers)
+        {
+            MouseButton = mouseButton;
+            Modifiers = modifiers;
+        }
+
+        public bool ShouldActivate(PointerDownEvent evt)
+        {
+            if (Modifiers != EventModifiers.None && Modifiers != evt.modifiers) return false;
+            if (MouseButton == (ManipulatorButton)evt.button) return true;
+            return false;
+        }
+    }
+
     internal abstract class BaseDragManipulator : PointerManipulator, IScalableManipulator
     {
         private Vector3 _startClickPosition;
         private Vector3 _deltaClickPosition;
         private bool _enabled;
-        private ManipulatorButton _activatorButton;
+        private ActivatorCombination[] _activators;
 
         protected Vector3 StartPosition => _startClickPosition;
 
@@ -41,10 +66,10 @@ namespace GiantParticle.InspectorGraph.Editor.Manipulators
             set => _movementScale = value;
         }
 
-        protected BaseDragManipulator(VisualElement handle, ManipulatorButton activatorButton = ManipulatorButton.Left)
+        protected BaseDragManipulator(VisualElement handle, ActivatorCombination[] activators = null)
         {
             this.target = handle;
-            _activatorButton = activatorButton;
+            _activators = activators ?? new[] { new ActivatorCombination(ManipulatorButton.Left) };
         }
 
         protected override void RegisterCallbacksOnTarget()
@@ -69,7 +94,18 @@ namespace GiantParticle.InspectorGraph.Editor.Manipulators
         {
             if (_enabled) return;
             if (target.HasPointerCapture(evt.pointerId)) return;
-            if (_activatorButton != (ManipulatorButton)evt.button) return;
+            bool activate = false;
+            for (int i = 0; i < _activators.Length; ++i)
+            {
+                ActivatorCombination combination = _activators[i];
+                if (combination.ShouldActivate(evt))
+                {
+                    activate = true;
+                    break;
+                }
+            }
+
+            if (!activate) return;
 
             _startClickPosition = evt.position;
             target.CapturePointer(evt.pointerId);

--- a/Editor/InspectorGraph/Manipulators/DragManipulator.cs
+++ b/Editor/InspectorGraph/Manipulators/DragManipulator.cs
@@ -17,8 +17,8 @@ namespace GiantParticle.InspectorGraph.Editor.Manipulators
         private bool _enabled;
 
         public DragManipulator(VisualElement handle, VisualElement target,
-            ManipulatorButton activatorButton = ManipulatorButton.Left) :
-            base(handle, activatorButton)
+            ActivatorCombination[] activators = null) :
+            base(handle, activators)
         {
             _dragTarget = target;
         }


### PR DESCRIPTION
## Fixed
* Fixed issue where trackpads cannot move the graph due to the lack of middle button. Now there are two (2) options to move graph that follow [shortcut conventions](https://docs.unity3d.com/Manual/SceneViewNavigation.html):
  * Using middle button
  * [macOS] Using combination of left button + Option Key + Command key
  * [Windows | Linux] Using combination of left button + Alt Key + Control key